### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/zedendale/7d121729-22ec-4291-a815-c3bd249f48b9/0c1026eb-cdde-441f-b988-8ccf4522263d/_apis/work/boardbadge/ed64da88-0f5e-4c36-8469-f1c4b56ed590)](https://dev.azure.com/zedendale/7d121729-22ec-4291-a815-c3bd249f48b9/_boards/board/t/0c1026eb-cdde-441f-b988-8ccf4522263d/Microsoft.RequirementCategory)
 # maven-project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/zedendale/7d121729-22ec-4291-a815-c3bd249f48b9/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.